### PR TITLE
Print error msg when matrix json is invalid

### DIFF
--- a/src/modules/parser.rs
+++ b/src/modules/parser.rs
@@ -134,8 +134,19 @@ impl EnterpriseMatrixParser {
         if _target_matrix == "None" {
             return Ok(());
         }
+	
+
+	
         let _bufr = FileHandler::load_resource("matrixes", _target_matrix);
-        let _json: serde_json::Value = serde_json::from_reader(_bufr).unwrap();
+        
+	let _json: serde_json::Value;
+	match serde_json::from_reader(_bufr) {
+	  Ok(v) =>  _json = v,
+	  Err(e) => panic!("Invalid json - check matrix file. Error: ".to_owned() + &e.to_string()),
+	};
+       
+	println!("o ACA");
+	
         let _scanner = PatternManager::load_subtechnique();
         let mut _is_subtechnique = false;
         for _t in _json["objects"].as_array().unwrap().iter() {

--- a/src/modules/parser.rs
+++ b/src/modules/parser.rs
@@ -133,20 +133,13 @@ impl EnterpriseMatrixParser {
         };
         if _target_matrix == "None" {
             return Ok(());
-        }
-	
-
-	
-        let _bufr = FileHandler::load_resource("matrixes", _target_matrix);
-        
+        }	
+        let _bufr = FileHandler::load_resource("matrixes", _target_matrix); 
 	let _json: serde_json::Value;
 	match serde_json::from_reader(_bufr) {
-	  Ok(v) =>  _json = v,
-	  Err(e) => panic!("Invalid json - check matrix file. Error: ".to_owned() + &e.to_string()),
+	    Ok(v) => _json = v,
+	    Err(e) => panic!("Invalid json - check matrix file. Error: ".to_owned() + &e.to_string()),
 	};
-       
-	println!("o ACA");
-	
         let _scanner = PatternManager::load_subtechnique();
         let mut _is_subtechnique = false;
         for _t in _json["objects"].as_array().unwrap().iter() {


### PR DESCRIPTION

Before
-------------------
Matrix Type For Baseline: enterprise
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("expected value", line: 1, column: 1)', src/./utils/../modules/parser.rs:138:71
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


After
-------------------
Matrix Type For Baseline: enterprise
thread 'main' panicked at 'Invalid json - check matrix file. Error: expected value at line 1 column 1', src/./utils/../modules/parser.rs:141:19
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

